### PR TITLE
移除通过传入环境变量来配置 NapCat 的方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,15 @@
 - [x] Linux/Amd64
 - [x] Linux/Arm64
 
-## 配置
-
-容器通过环境变量来配置，环境变量名称可以查看 [entrypoint](./entrypoint.sh)👈
-
-具体参数可参考[官方文档](https://napneko.com/config/basic#%E9%85%8D%E7%BD%AE%E5%86%85%E5%AE%B9%E5%8F%82%E6%95%B0%E8%A7%A3%E9%87%8A)
-
 # 启动容器
-
-## 正向 WS
 
 ### 命令行运行
 
 ```shell
 docker run -d \
--e ACCOUNT=<机器人qq> \
--e WS_ENABLE=true \
 -e NAPCAT_GID=$(id -g) \
 -e NAPCAT_UID=$(id -u) \
+-p 3000:3000 \
 -p 3001:3001 \
 -p 6099:6099 \
 --name napcat \
@@ -40,11 +31,10 @@ version: "3"
 services:
     napcat:
         environment:
-            - ACCOUNT=<机器人qq>
-            - WS_ENABLE=true
             - NAPCAT_UID=${NAPCAT_UID}
             - NAPCAT_GID=${NAPCAT_GID}
         ports:
+            - 3000:3000
             - 3001:3001
             - 6099:6099
         container_name: napcat
@@ -55,95 +45,6 @@ services:
 
 使用 `NAPCAT_UID=$(id -u) NAPCAT_GID=$(id -g) docker-compose up -d` 运行到后台
 
-## 反向 WS
-<details>
-<summary>点我查看命令👈</summary>
-
-### 命令行运行
-
-```shell
-docker run -d \
--e ACCOUNT=<机器人qq> \
--e WSR_ENABLE=true \
--e WS_URLS='["ws://192.168.3.8:5140/onebot"]' \
--e NAPCAT_GID=$(id -g) \
--e NAPCAT_UID=$(id -u) \
---name napcat \
---restart=always \
-mlikiowa/napcat-docker:latest
-```
-### docker-compose 运行
-
-按照 [正向 WS](#docker-compose-运行) 中的方式创建 `.env` 文件，然后创建 `docker-compose.yml` 文件
-```yaml
-# docker-compose.yml
-version: "3"
-services:
-    napcat:
-        environment:
-            - ACCOUNT=<机器人qq>
-            - WSR_ENABLE=true
-            - WS_URLS=["ws://192.168.3.8:5140/onebot"]
-            - NAPCAT_UID=${NAPCAT_UID}
-            - NAPCAT_GID=${NAPCAT_GID}
-        container_name: napcat
-        network_mode: bridge
-        ports:
-           - 6099:6099
-        restart: always
-        image: mlikiowa/napcat-docker:latest
-```
-
-使用 `NAPCAT_UID=$(id -u) NAPCAT_GID=$(id -g) docker-compose up -d` 运行到后台
-</details>
-
-## HTTP
-<details>
-<summary>点我查看命令👈</summary>
-
-### 命令行运行
-
-```shell
-docker run -d \
--e ACCOUNT=<机器人qq> \
--e HTTP_ENABLE=true \
--e HTTP_POST_ENABLE=true \
--e HTTP_URLS='["http://192.168.3.8:5140/onebot"]' \
--e NAPCAT_GID=$(id -g) \
--e NAPCAT_UID=$(id -u) \
--p 3000:3000 \
--p 6099:6099 \
---name napcat \
---restart=always \
-mlikiowa/napcat-docker:latest
-```
-
-### docker-compose 运行
-
-按照 [正向 WS](#docker-compose-运行) 中的方式创建 `.env` 文件，然后创建 `docker-compose.yml` 文件
-```yaml
-# docker-compose.yml
-version: "3"
-services:
-    napcat:
-        environment:
-            - ACCOUNT=<机器人qq>
-            - HTTP_ENABLE=true
-            - HTTP_POST_ENABLE=true
-            - HTTP_URLS=["http://192.168.3.8:5140/onebot"]
-            - NAPCAT_UID=${NAPCAT_UID}
-            - NAPCAT_GID=${NAPCAT_GID}
-        ports:
-            - 3000:3000
-            - 6099:6099
-        container_name: napcat
-        network_mode: bridge
-        restart: always
-        image: mlikiowa/napcat-docker:latest
-```
-
-使用 `NAPCAT_UID=$(id -u) NAPCAT_GID=$(id -g) docker-compose up -d` 运行到后台
-</details>
 
 # 固化路径，方便下次直接快速登录
 
@@ -151,13 +52,9 @@ QQ 持久化数据路径：/app/.config/QQ
 
 NapCat 配置文件路径: /app/napcat/config
 
-注意：如果是重新创建的容器，需要固定 Mac 地址
-
 # 登录
 
-```shell
-docker logs napcat
-```
+登录 WebUI 地址：http://<宿主机ip>:6099/webui
 
 # Tips
 关于 NAPCAT_UID 与 NAPCAT_GID 环境变量

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-chech_quotes(){
-    local input="$1"
-    if [ "${input:0:1}" != '"' ] ; then
-        if [ "${input:0:1}" != '[' ] ; then
-            input="[\"$input\"]"
-        fi
-    else
-        input="[$input]"
-    fi
-    echo $input
-}
-
 # 安装 napcat
 if [ ! -f "napcat/napcat.mjs" ]; then
     unzip -q NapCat.Shell.zip -d ./NapCat.Shell
@@ -24,73 +12,26 @@ if [ ! -f "napcat/config/napcat.json" ]; then
     rm -rf ./NapCat.Shell
 fi
 
-CONFIG_PATH=napcat/config/onebot11_$ACCOUNT.json
-# 容器首次启动时执行
-if [ ! -f "$CONFIG_PATH" ]; then
-    if [ "$WEBUI_TOKEN" ]; then
-        echo "{\"port\": 6099,\"token\": \"$WEBUI_TOKEN\",\"loginRate\": 3}" > napcat/config/webui.json
-    fi
-    : ${WEBUI_TOKEN:=''}
-    : ${HTTP_PORT:=3000}
-    : ${HTTP_URLS:='[]'}
-    : ${WS_PORT:=3001}
-    : ${HTTP_ENABLE:='false'}
-    : ${HTTP_POST_ENABLE:='false'}
-    : ${WS_ENABLE:='false'}
-    : ${WSR_ENABLE:='false'}
-    : ${WS_URLS:='[]'}
-    : ${HEART_INTERVAL:=60000}
-    : ${TOKEN:=''}
-    : ${F2U_ENABLE:='false'}
-    : ${DEBUG_ENABLE:='false'}
-    : ${LOG_ENABLE:='false'}
-    : ${RSM_ENABLE:='false'}
-    : ${MESSAGE_POST_FORMAT:='array'}
-    : ${HTTP_HOST:=''}
-    : ${WS_HOST:=''}
-    : ${HTTP_HEART_ENABLE:='false'}
-    : ${MUSIC_SIGN_URL:=''}
-    : ${HTTP_SECRET:=''}
-    : ${NAPCAT_GID:=0}
-    : ${NAPCAT_UID:=0}
-    HTTP_URLS=$(chech_quotes $HTTP_URLS)
-    WS_URLS=$(chech_quotes $WS_URLS)
-cat <<EOF > $CONFIG_PATH
+# 配置 WebUI Token
+CONFIG_PATH=/app/napcat/config/webui.json
+if [ ! -f "${CONFIG_PATH}" ] && [ -n "${WEBUI_TOKEN}" ]; then
+    echo "正在配置 WebUI Token..."
+    cat > "${CONFIG_PATH}" << EOF
 {
-    "http": {
-      "enable": ${HTTP_ENABLE},
-      "host": "$HTTP_HOST",
-      "port": ${HTTP_PORT},
-      "secret": "$HTTP_SECRET",
-      "enableHeart": ${HTTP_HEART_ENABLE},
-      "enablePost": ${HTTP_POST_ENABLE},
-      "postUrls": $HTTP_URLS
-    },
-    "ws": {
-      "enable": ${WS_ENABLE},
-      "host": "${WS_HOST}",
-      "port": ${WS_PORT}
-    },
-    "reverseWs": {
-      "enable": ${WSR_ENABLE},
-      "urls": $WS_URLS
-    },
-    "GroupLocalTime":{
-      "Record": false,
-      "RecordList": []
-    },
-    "debug": ${DEBUG_ENABLE},
-    "heartInterval": ${HEART_INTERVAL},
-    "messagePostFormat": "$MESSAGE_POST_FORMAT",
-    "enableLocalFile2Url": ${F2U_ENABLE},
-    "musicSignUrl": "$MUSIC_SIGN_URL",
-    "reportSelfMessage": ${RSM_ENABLE},
-    "token": "$TOKEN"
+    "host": "0.0.0.0",
+    "prefix": "",
+    "port": 6099,
+    "token": "${WEBUI_TOKEN}",
+    "loginRate": 3
 }
 EOF
 fi
+
+
 rm -rf "/tmp/.X1-lock"
 
+: ${NAPCAT_GID:=0}
+: ${NAPCAT_UID:=0}
 usermod -o -u ${NAPCAT_UID} napcat
 groupmod -o -g ${NAPCAT_GID} napcat
 usermod -g ${NAPCAT_GID} napcat
@@ -102,4 +43,5 @@ sleep 2
 export FFMPEG_PATH=/usr/bin/ffmpeg
 export DISPLAY=:1
 cd /app/napcat
+ACCOUNT=$(ls /app/napcat/config/ | grep -oE '[1-9][0-9]{4,12}' | head -n 1)
 gosu napcat /opt/QQ/qq --no-sandbox -q $ACCOUNT


### PR DESCRIPTION
- 目前通过 NapCat WebUI 配置 NapCat 已经非常方便。
- 就算不使用 WebUI，也可以通过挂载数据卷的方法来配置 NapCat。
- 传入的环境变量的管理方法已经非常臃肿，维护起来非常困难。
- 通过传入环境变量来配置 NapCat 的方法灵活性太低。