### PR TITLE
修改volume路径

### DIFF
--- a/compose/ws.yml
+++ b/compose/ws.yml
@@ -17,5 +17,5 @@ services:
       - 6099:6099
     
     volumes:
-      - ./napcat:/app/napcat
+      - ./napcat:/app/napcat/config
       - ./ntqq:/app/.config/QQ


### PR DESCRIPTION
修改volume路径，使得配置文件能够正常同步到宿主机./napcat目录下，由于我只使用了ws，故只对ws进行了修改
#69 