### PR TITLE
Revise Docker run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ mlikiowa/napcat-docker:latest
 ```
 
 ```shell
-（ps：在win下部署 以上代码docker萌新小白可能会直接复制粘贴导致报错，提交一个可以直接复制粘贴用的，
- 按照astrbot默认端口建议6199所以新加了个6199，那个uid还没搞清楚是什么）
-docker run -d -p 6099:6099  -p 3001:3001 -p 6199:6199 --name napcat --restart=always mlikiowa/napcat-docker:latest
+（ps：在win下部署 以上代码docker萌新小白可能会直接复制粘贴导致报错，提交一个可以直接复制粘贴用的，目前还没搞清楚uid是什么）
+docker run -d -p 6099:6099  -p 3001:3001 --name napcat --restart=always mlikiowa/napcat-docker:latest
 ```
 
 ### docker-compose 运行
@@ -37,7 +36,6 @@ docker run -d -p 6099:6099  -p 3001:3001 -p 6199:6199 --name napcat --restart=al
 创建 `docker-compose.yml` 文件
 ```yaml
 # docker-compose.yml
-version: "3"
 services:
     napcat:
         environment:


### PR DESCRIPTION
Updated Docker run command for clarity and usability. 如果NapCat启动时占用了6199,会导致其与AstrBot同机共同部署时产生端口占用冲突。