### PR TITLE
feat: add qq-ai-bot compose template

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ NapCat 插件目录路径: /app/napcat/plugins
 
 [Koishi Compose模板](./compose/koishi.yml)
 
+[qq-ai-bot Compose模板](./compose/qq-ai-bot.yml)
+
 [WebsockServer Compose模板](./compose/ws.yml)
 
 > 欢迎Pr.此方案快速填充NapCat侧配置,你只需要配置应用侧,注意当你不需要WebUi或者处于公网环境,请注意6099端口和WebUi默认密码。

--- a/compose/qq-ai-bot.yml
+++ b/compose/qq-ai-bot.yml
@@ -1,0 +1,53 @@
+# qq-ai-bot & NapCat Docker Compose 配置文件
+# 启动命令: NAPCAT_UID=$(id -u) NAPCAT_GID=$(id -g) docker-compose -f ./compose/qq-ai-bot.yml up -d
+services:
+  napcat:
+    container_name: napcat
+    image: mlikiowa/napcat-docker:latest
+    restart: always
+    environment:
+      - NAPCAT_UID=${NAPCAT_UID:-1000}
+      - NAPCAT_GID=${NAPCAT_GID:-1000}
+      - WEBUI_TOKEN=${WEBUI_TOKEN:-napcat}
+      - MODE=qq-ai-bot
+    ports:
+      - 3000:3000
+      - 6099:6099
+    volumes:
+      - ./napcat/config:/app/napcat/config
+      - ./napcat/QQ:/app/.config/QQ
+    networks:
+      - qq_ai_bot_network
+    mac_address: "02:42:ac:11:00:02"
+
+  qq-ai-bot:
+    container_name: qq-ai-bot
+    image: ghcr.io/happysnaker/qq-ai-bot:latest
+    restart: always
+    environment:
+      - BOT_PORT=8080
+      - DATA_DIR=/app/data
+      - SESSION_FILE_PATH=/app/data/sessions.json
+      - ONEBOT_MODE=reverse
+      - ONEBOT_REVERSE_WS_HOST=0.0.0.0
+      - ONEBOT_REVERSE_WS_PORT=16700
+      - ONEBOT_REVERSE_WS_PATH=/onebot/v11/ws
+      - ONEBOT_ALLOW_GROUP=true
+      - ONEBOT_REQUIRE_MENTION_IN_GROUP=true
+      - ONEBOT_ALLOW_PRIVATE=true
+      - ONEBOT_PROGRESS_MODE=message
+      - ACP_AGENT_COMMAND=node
+      - 'ACP_AGENT_ARGS_JSON=["dist/examples/mock-acp-agent.js"]'
+      - ACP_AGENT_WORKDIR=/app
+      - ACP_REUSE_SESSION=true
+      - ACP_VERBOSE_MODE=verbose
+    ports:
+      - 18080:8080
+    volumes:
+      - ./qq-ai-bot/data:/app/data
+    networks:
+      - qq_ai_bot_network
+
+networks:
+  qq_ai_bot_network:
+    driver: bridge

--- a/templates/templates/qq-ai-bot.json
+++ b/templates/templates/qq-ai-bot.json
@@ -1,0 +1,25 @@
+{
+  "network": {
+    "httpServers": [],
+    "httpSseServers": [],
+    "httpClients": [],
+    "websocketServers": [],
+    "websocketClients": [
+      {
+        "enable": true,
+        "name": "qq-ai-bot-rws",
+        "url": "ws://qq-ai-bot:16700/onebot/v11/ws",
+        "reportSelfMessage": false,
+        "messagePostFormat": "array",
+        "token": "",
+        "debug": false,
+        "heartInterval": 30000,
+        "reconnectInterval": 30000
+      }
+    ],
+    "plugins": []
+  },
+  "musicSignUrl": "",
+  "enableLocalFile2Url": false,
+  "parseMultMsg": false
+}


### PR DESCRIPTION
## Summary
- add a `qq-ai-bot` compose template alongside existing NapCat ecosystem templates
- add the matching `MODE=qq-ai-bot` OneBot reverse WebSocket template
- document the new template entry in README

## Why
`qq-ai-bot` is a self-hosted QQ ↔ AI bot built around NapCat / LLOneBot + OneBot 11 + ACP agent bridging. A dedicated compose template makes it easier for NapCat users to try a production-oriented AI bot stack with session persistence and progress streaming.

## Notes
- the template keeps `ONEBOT_ACCESS_TOKEN` empty by default for minimum-friction local setup, consistent with other quickstart-style templates
- the bot image is published at `ghcr.io/happysnaker/qq-ai-bot:latest`
- the default ACP backend in this template is the repo's built-in mock agent so users can validate the QQ -> OneBot -> bot chain first, then replace it with their own ACP agent later
