### PR TITLE
fix: copy preset templates to /app/templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN useradd --no-log-init -d /app napcat
 
 WORKDIR /app
 
-COPY NapCat.Shell.zip entrypoint.sh templates /app/
+COPY NapCat.Shell.zip entrypoint.sh /app/
+COPY templates/templates/ /app/templates/
 
 # 安装Linux QQ（带重试，外网可能不稳定）
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
@@ -24,4 +25,3 @@ VOLUME /app/napcat/config
 VOLUME /app/.config/QQ
 
 ENTRYPOINT ["bash", "entrypoint.sh"]
-

--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ NapCat 插件目录路径: /app/napcat/plugins
 [WebsockServer Compose模板](./compose/ws.yml)
 
 > 欢迎Pr.此方案快速填充NapCat侧配置,你只需要配置应用侧,注意当你不需要WebUi或者处于公网环境,请注意6099端口和WebUi默认密码。
+
+> `MODE=qq-ai-bot` 会使用镜像内置的 `qq-ai-bot` OneBot11 预设模板生成 `/app/napcat/config/onebot11.json`。


### PR DESCRIPTION
This fixes the preset-template copy path in the image build.\n\nWhy this matters:\n-  copies preset configs from \n- but the repository currently stores preset files under  and the Dockerfile copies the whole  directory into \n- that means the built image ends up with files under  only if the copy layout happens to flatten as expected; the current repository layout and image contents drifted for the  preset and the new preset was missing from the published image\n\nThis PR makes the Dockerfile copy  directly into , which matches what  already expects.\n\nAlso added one short README note clarifying that  uses the bundled preset template.