### PR TITLE
Fix Docker command for easier copy-paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ docker run -d \
 mlikiowa/napcat-docker:latest
 ```
 
-```shell
 （ps：在win下部署 以上代码docker萌新小白可能会直接复制粘贴导致报错，提交一个可以直接复制粘贴用的，
  按照astrbot默认端口建议6199所以新加了个6199，那个uid还没搞清楚是什么）
-docker run -d -p 6099:6099  -p 3001:3001 -p 6199:6199 --name napcat --restart=always mlikiowa/napcat-docker:latest
+```shell
+docker run -d -p 6099:6099 -p 3001:3001 -p 6199:6199 --name napcat --restart=always mlikiowa/napcat-docker:latest
 ```
 
 ### docker-compose 运行


### PR DESCRIPTION
说明文字应该在代码块的外面或者使用注释
避免小白复制多内容
虽然第一行报错第二行还是能跑